### PR TITLE
Added details pane with messaging and editing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ These shortcuts apply to the issue under the mouse cursor:
 - Press `c` to complete/close an issue, and `C` to undo
 - Press `d` to mark as `⏳ Doing` and `D` to undo
 - Press `r` to mark as in `👓 Review` and `R` to undo
+- Press `e` to edit the issue (and Enter to save)
 - Press `x` to delete an issue (confirmation required)
 - Press `0` to set priority to `🔥 P0`
 - Press `1` to set priority to `⭐️ P1`

--- a/package.json
+++ b/package.json
@@ -11,11 +11,16 @@
     "graphql": "^15.3.0",
     "graphql-anywhere": "^4.2.7",
     "http-proxy-middleware": "^2.0.0",
+    "javascript-time-ago": "^2.5.7",
     "node-fetch": "latest",
     "qs": "^6.11.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-scripts": "^4.0.3"
+    "react-markdown": "^8.0.3",
+    "react-scripts": "^4.0.3",
+    "react-time-ago": "^7.2.1",
+    "relative-time-format": "^1.1.4",
+    "remark-gfm": "^3.0.1"
   },
   "scripts": {
     "start": "tsc && npm run development",

--- a/src/components/graphql/IssueDetail.tsx
+++ b/src/components/graphql/IssueDetail.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useEffect } from 'react';
+import { Issue as IssueType } from 'data/types';
+import DetailPane from 'components/presentation/DetailPane';
+import { useQuery, useMutation } from '@apollo/client';
+import { ISSUE_DETAIL, CREATE_NOTE, UPDATE_ISSUE } from 'data/queries';
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { organization } from 'data/customize';
+import { projects } from 'data/projects';
+import { primaryLabelForIssue } from 'data/labels';
+import { polling } from 'data/polling';
+import ChatBubble from 'components/presentation/ChatBubble';
+import GrowingText from 'components/presentation//GrowingText';
+
+interface IssueDetailProps {
+  issueId?: string;
+  onClose?(): void;
+}
+
+const IssueDetail: React.FC<IssueDetailProps> = (props) => {
+
+  // Lookup the given issue
+  const issueDetailQuery = useQuery(ISSUE_DETAIL, { variables: { id: props.issueId } });
+  const issue: IssueType = issueDetailQuery.data?.issue; 
+  const primaryLabel = issue ? primaryLabelForIssue(issue) : {};
+
+  // Poll for changes to open issues 
+  // (fix for bug in Apollo that doesn't stop polling when you navigate away)
+  const startPolling = issueDetailQuery.startPolling;
+  const stopPolling = issueDetailQuery.stopPolling;
+  useEffect(() => {
+    startPolling(polling.frequency.issueDetail);
+    return () => {
+      stopPolling();
+    }
+  }, [startPolling, stopPolling])
+
+  // Find the project name for this issue
+  const projectName: string | undefined = Object.keys(projects).find(project => projects[project] === issue?.projectId);
+
+  // Transformations for links and images 
+  const transformLinkUri = (href, children, title) => href?.indexOf('://') > 0 ? href : `https://gitlab.com/${href}`;
+  const transformImageUri = (src, alt, title) => `https://gitlab.com/${organization}/${projectName}${src}`;
+
+  // Filter out the user notes (not the system messages)
+  const userNotes = issue?.notes?.nodes?.filter(note => !note.system)
+  const sortedUserNotes = userNotes?.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+  // Update the issue if anything is changed
+  const refetchQueries = [{ query: ISSUE_DETAIL, variables: { id: props.issueId } }];
+
+  // Mutation to create a note (and re-fetch the issue right after)
+  // We also will re-focus on the note after the new one is received so the user can type the next comment
+  const [focusRequestedAt, setFocusRequestedAt] = useState<number | undefined>(undefined);
+  const [createNote] = useMutation(CREATE_NOTE, { refetchQueries, onCompleted(data) {
+    setFocusRequestedAt(new Date().getTime());
+  }, });
+  const handleCreateNote = (rawText: string) => {
+    createNote({ variables: { projectId: issue?.projectId, issueId: issue?.iid, input: { body: rawText } } });
+  }
+
+  // Are we editing the description?
+  const [isEditingDescription, setEditingDescription] = useState<boolean>(false);
+  const [editableDescription, setEditableDescription] = useState<string>(issue?.description || '');
+  const [descriptionFocusRequestedAt, setDescriptionFocusRequestedAt] = useState<number | undefined>(undefined);
+  useEffect(() => {
+    setEditableDescription(issue?.description || '');
+  }, [issue?.description])
+
+  // If the issue changes, clear the editing state
+  useEffect(() => {
+    setEditingDescription(false);
+  }, [issue?.iid])
+
+  // Save on command
+  const [updateIssue] = useMutation(UPDATE_ISSUE, { refetchQueries });
+  const handleSaveDescription = () => {
+    updateIssue({ variables: { projectId: issue?.projectId, id: issue?.iid, input: { description: editableDescription } } });
+    setEditingDescription(false);
+  }
+
+  // The content of the pane
+  const content = () => {
+    if ( isEditingDescription ) {
+      return (
+        <GrowingText
+          placeholder='Enter a description...'
+          text={editableDescription}
+          focusRequestedAt={descriptionFocusRequestedAt}
+          onChange={(text) => { setEditableDescription(text); }}
+        />
+      )
+    }
+    else {
+      return (
+        <div>
+          <ReactMarkdown 
+            children={issue?.description || ''}
+            remarkPlugins={[remarkGfm]}
+            transformLinkUri={transformLinkUri}
+            transformImageUri={transformImageUri}
+          />
+          {
+            sortedUserNotes.map(note => {
+              return (
+                <ChatBubble who={note.author?.name} when={note.createdAt}>
+                  <ReactMarkdown 
+                    children={note?.body || ''}
+                    remarkPlugins={[remarkGfm]}
+                    transformLinkUri={transformLinkUri}
+                    transformImageUri={transformImageUri}
+                  />
+                </ChatBubble>
+              );
+            })
+          }
+          <ChatBubble 
+            who='You' 
+            isEditing={true} 
+            focusRequestedAt={focusRequestedAt} 
+            onSend={(rawText) => { handleCreateNote(rawText) }}
+          />
+        </div>
+      )
+    }
+  }
+
+  // Do we have an issue ID?
+  if ( props.issueId && issue ) {
+    return (
+      <DetailPane 
+        icon={primaryLabel?.icon} 
+        title={`${issue?.iid}`} 
+        titleUrl={`https://gitlab.com/${issue.webPath}`}
+        titleTip={issue?.title}
+        subtitle={issue?.title}
+        isEditing={isEditingDescription}
+        onSave={() => { handleSaveDescription() }}
+        onEditing={(editing: boolean) => { 
+          setEditingDescription(editing); 
+          if ( editing ) {
+            setDescriptionFocusRequestedAt(new Date().getTime()); 
+          }
+        }} 
+      >
+        {content()}
+      </DetailPane>
+    )
+  }
+  else {
+    return <div/>;
+  }
+}
+
+export default IssueDetail;

--- a/src/components/graphql/Planner.tsx
+++ b/src/components/graphql/Planner.tsx
@@ -6,11 +6,12 @@ import Milestone from './Milestone';
 import { teams } from 'data/teams';
 import { upcomingMilestones, recentMilestones, currentMilestone } from 'data/milestones';
 import { Filter, FilterReadouts, Team, Milestone as MilestoneType } from 'data/types';
-import { FILTER, OPEN_UNASSIGNED_ISSUES, OPEN_EPICS, ALL_BUG_ISSUES } from 'data/queries';
+import { FILTER, OPEN_UNASSIGNED_ISSUES, OPEN_EPICS, ALL_BUG_ISSUES, SELECTED_ISSUE } from 'data/queries';
 import { useQuery, useApolloClient } from '@apollo/client';
 import { polling } from 'data/polling';
 import { organization } from 'data/customize';
 import IssueMilestones from 'components/graphql/IssueMilestones';
+import IssueDetail from 'components/graphql/IssueDetail';
 
 interface PlannerProps {
 }
@@ -113,6 +114,22 @@ const Planner: React.FC<PlannerProps> = (props: PlannerProps) => {
     return <Milestone filter={filter} epics={epics}/>
   }
 
+  // Lookup the selected issue ID, if there is one
+  const selectedIssueQuery = useQuery(SELECTED_ISSUE);
+  const selectedIssueId = selectedIssueQuery.data?.selectedIssueId;
+
+  // Create our details pane
+  const details = (): React.ReactNode | undefined => {
+
+    // Don't show for any non-issue panes
+    if ( filter.username === 'diffs' || filter.username === 'links' ) {
+      return undefined;
+    }
+
+    // Let's see if there's a selected issue right now
+    return <IssueDetail issueId={selectedIssueId}/>
+  }
+
   return (
     <div>
       <Header>
@@ -121,7 +138,7 @@ const Planner: React.FC<PlannerProps> = (props: PlannerProps) => {
                    onChangeFilter={handleChangeFilter}
                    onChooseMilestone={() => setChoosingMilestone(true)}/>
       </Header>
-      <Arena>
+      <Arena detailPane={details()}>
         {milestones()}
         {milestonePicker()}
       </Arena>

--- a/src/components/presentation/Action.module.css
+++ b/src/components/presentation/Action.module.css
@@ -23,7 +23,8 @@
   vertical-align: top;
 }
 
-.Action[undo='true'] {
+.Action[undo='true'] .ActionName,
+.Action[undo='true'] .ActionIcon {
   opacity: 0.5;
 }
 
@@ -38,6 +39,29 @@
 
 .Action[undo='true']:hover .ActionName {
 /*  color: rgba(255,0,0,1);*/
+}
+
+.ActionShortcut {
+  font-size: 0.9em;
+  color: rgba(0,0,0,0.35);
+  background-color: rgba(0,0,0,0.05);
+  border: 1px solid rgba(0,0,0,0.05);
+  border-radius: 3px;
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  margin-left: 6px;
+  margin-right: 12px;
+  margin-top: -5px;
+  vertical-align: middle;
+  line-height: 16px;
+  text-align: center;
+}
+
+.Action:hover .ActionShortcut {
+  color: rgba(0,0,0,0.7);
+  background-color: rgba(0,0,0,0.1);
+  border: 1px solid rgba(0,0,0,0.1);
 }
 
 

--- a/src/components/presentation/Action.tsx
+++ b/src/components/presentation/Action.tsx
@@ -4,6 +4,7 @@ import { Action as ActionType } from 'data/types';
 
 interface ActionProps {
   action: ActionType;
+  isShowingShortcut?: boolean;
   onClick(): void;
 }
 
@@ -15,6 +16,13 @@ const Action: React.FC<ActionProps> = (props: ActionProps) => {
     }
   }
 
+  const shortcut = () => {
+    if ( props.action.shortcut && props.isShowingShortcut) {
+      return <span className={styles.ActionShortcut}>{props.action.shortcut}</span>
+    }
+    return undefined;
+  }
+
   return (
     <span 
       className={styles.Action} 
@@ -24,6 +32,7 @@ const Action: React.FC<ActionProps> = (props: ActionProps) => {
     >
       <span className={styles.ActionIcon}>{props.action.icon}</span>
       <span className={styles.ActionName}>{props.action.name}</span>
+      {shortcut()}
     </span>
   );
 }

--- a/src/components/presentation/Actions.tsx
+++ b/src/components/presentation/Actions.tsx
@@ -5,6 +5,7 @@ import styles from './Actions.module.css';
 
 interface ActionsProps {
   actions: ActionType[];
+  isShowingShortcuts?: boolean;
   onClickAction(action: ActionType): void;
 }
 
@@ -19,7 +20,14 @@ const Actions: React.FC<ActionsProps> = (props: ActionsProps) => {
   return (
     <div className={styles.Actions}>
       {props.actions.map((action: ActionType) => {
-        return <Action key={action.name} action={action} onClick={() => handleClickAction(action)}/>
+        return (
+          <Action 
+            key={action.name} 
+            action={action} 
+            isShowingShortcut={props.isShowingShortcuts} 
+            onClick={() => handleClickAction(action)}
+          />
+        )
       })}
     </div>
   );

--- a/src/components/presentation/Arena.module.css
+++ b/src/components/presentation/Arena.module.css
@@ -1,3 +1,17 @@
 .Arena {
-  margin-top: 5.5em;
+  margin-top: 5em;
+  display: flex;
+  flex-direction: row;
+}
+
+.MainPane {
+  min-width: 1224px;
+}
+
+.DetailPane {
+  position: fixed;
+  left: 1220px;
+  flex-direction: column;
+  width: calc(100vw - 1240px);
+  height: calc(100vh - 7em);
 }

--- a/src/components/presentation/Arena.tsx
+++ b/src/components/presentation/Arena.tsx
@@ -3,12 +3,14 @@ import styles from './Arena.module.css';
 
 interface ArenaProps {
   children?: React.ReactNode;
+  detailPane?: React.ReactNode;
 }
 
 const Arena:React.FC<ArenaProps> = (props: ArenaProps) => {
   return (
     <div className={styles.Arena}>
-      {props.children}
+      <span className={styles.MainPane}>{props.children}</span>
+      <span className={styles.DetailPane}>{props.detailPane}</span>
     </div>
   );
 }

--- a/src/components/presentation/Button.module.css
+++ b/src/components/presentation/Button.module.css
@@ -5,6 +5,7 @@
   height: 2.25em;
   border: none; 
   background-color: #7E57FF;
+  border: 1px solid #7E57FF;
   border-radius: 5px;
   font-size: 1em;
   font-weight: bold;
@@ -17,16 +18,29 @@
 
 .Button[isdisabled='true'] {
   background-color: #BFC6D1;
+  border: 1px solid #BFC6D1;
 }
 
-.Button[issmall='true'] {
-  height: 1.75em;
-  padding-top: 0.5em;
+.Button[vastness='medium'] {
+  height: 1.6em;
+  padding-top: 0.35em;
   width: auto;
   padding-left: 1em;
   padding-right: 1em;
   margin-top: 0em;
   margin-bottom: 0em;
+}
+
+.Button[vastness='small'] {
+  height: 0.96em;
+  width: auto;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  padding-top: 0.15em;
+  padding-bottom: 0.4em;
+  margin-top: 0em;
+  margin-bottom: 0em;
+  font-size: 0.95em;
 }
 
 .ButtonText {
@@ -35,5 +49,22 @@
 
 .Button:hover {
   background-color: #A78DFF;
+  border: 1px solid #A78DFF;
 }
 
+.Button[secondary='true'] {
+  font-weight: 500;
+  background-color: rgba(0,0,0,0);
+  border: 1px solid #7E57FF;
+  color: #7E57FF;
+  border: 1px solid rgba(0,0,0,0.35);
+  color: rgba(0,0,0,0.45);
+  /*background-color: rgba(0,0,0,0.05);
+  border: 1px solid rgba(0,0,0,0.1);*/
+}
+
+.Button[secondary='true']:hover {
+  background-color: rgba(0,0,0,0);
+  border: 1px solid rgba(0,0,0,0.25);
+  color: rgba(0,0,0,0.35);
+}

--- a/src/components/presentation/Button.tsx
+++ b/src/components/presentation/Button.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import styles from './Button.module.css';
 
+type ButtonSizeType = 'large' | 'medium' | 'small'
+
 interface ButtonProps {
   title: string;
-  isSmall?: boolean;
+  size?: ButtonSizeType;
   isDisabled?: boolean;
+  isSecondary?: boolean;
   onClick(): void;
 }
 
@@ -18,7 +21,7 @@ const Button: React.FC<ButtonProps> = (props) => {
     }
   }
   
-  const customProps = { issmall: `${props.isSmall}`, isdisabled: `${props.isDisabled}`};
+  const customProps = { vastness: `${props.size}`, isdisabled: `${props.isDisabled}`, secondary: `${props.isSecondary}` };
   return (
     <div className={styles.Button} {...customProps} onClick={handleClick}>
       <div className={styles.ButtonText}>{props.title}</div>

--- a/src/components/presentation/Card.module.css
+++ b/src/components/presentation/Card.module.css
@@ -27,7 +27,7 @@
   text-decoration: none;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
   "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",sans-serif;
-  font-size: 1.5em;
+  font-size: 1.2em;
   font-weight: bold;
 }
 

--- a/src/components/presentation/ChatBubble.module.css
+++ b/src/components/presentation/ChatBubble.module.css
@@ -1,0 +1,33 @@
+.ChatBubble {
+  border-radius: 10px;
+  background-color: rgba(255,255,255,0.7);  
+  border: 1px solid rgba(0,0,0,0.09);
+  padding: 1em 1em 0.25em 1em;
+  width: calc(100% - 2.25em);
+  max-width: 600px;
+  margin-top: 1.5em;
+}
+
+.ChatBubble + .ChatBubble {
+  margin-top: 1em;
+}
+
+.BubbleHeader {
+  display: flex;
+  flex-direction: row;
+  height: 1.5em;
+}
+
+.BubbleAuthor {
+  font-weight: 600;
+  flex-grow: 1;
+}
+
+.BubbleIcon {
+  display: inline-block;
+  margin-right: 0.5em;
+}
+
+.BubbleTime {
+  color: rgba(0,0,0,0.5);
+}

--- a/src/components/presentation/ChatBubble.tsx
+++ b/src/components/presentation/ChatBubble.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect, useRef } from 'react';
+import styles from './ChatBubble.module.css';
+import ReactTimeAgo from 'react-time-ago'
+import Button from  '../presentation/Button';
+import GrowingText from '../presentation/GrowingText';
+
+interface ChatBubbleProps {
+  who?: string;
+  when?: Date;
+  rawText?: string;
+  children?: React.ReactNode;
+  isEditing?: boolean;
+  focusRequestedAt?: number;
+  onSend?(rawText: string): void;
+}
+
+const ChatBubble:React.FC<ChatBubbleProps> = (props: ChatBubbleProps) => {
+  
+  // Start our internal editable text with any raw text passed in
+  const [editableText, setEditableText] = useState(props.rawText || '');
+
+  // This helps us clear the text on demand
+  const [clearRequestedAt, setClearRequestedAt] = useState<number | undefined>();
+
+  // When the user presses send, pass the value to the parent and clear the text
+  const handleClickSend = () => {
+
+    // Send text to parent (who will send to the server)
+    props.onSend?.(editableText);
+
+    // Clear the text
+    setClearRequestedAt(new Date().getTime());
+  }
+
+  // Support either showing readable rendered markdown, or editable text
+  const content = () => {
+    if ( props.isEditing ) {
+      return (
+        <GrowingText 
+          placeholder='Type message here...' 
+          text={editableText} 
+          onChange={(text: string) => setEditableText(text)} 
+          focusRequestedAt={props.focusRequestedAt} 
+          clearRequestedAt={clearRequestedAt} 
+        />
+      )
+    }
+    return props.children;
+  }
+
+  const icon = () => { return '💬'; }
+
+  const elapsed = () => {
+    if ( props.when ) {
+      return (
+        <span className={styles.BubbleTime}>
+          <ReactTimeAgo date={props.when} locale="en-US"/>
+        </span>
+      )
+    }
+    return undefined;
+  }
+
+  const button = () => {
+    if ( props.isEditing && editableText?.length ) {
+      return (
+        <div className={styles.BubbleButton}>
+          <Button title='Send' size='small' onClick={() => { handleClickSend() }}/>
+        </div>
+      )
+    }
+    return undefined;
+  }
+
+  return (
+    <div className={styles.ChatBubble}>
+      <div className={styles.BubbleHeader}>
+        <span className={styles.BubbleAuthor}>
+          <span className={styles.BubbleIcon}>{icon()}</span>
+          {props.who}
+        </span>
+        {elapsed()}
+        {button()}
+      </div>
+      <div className={styles.BubbleContent}>
+        {content()}
+      </div>
+    </div>
+  )
+}
+
+export default ChatBubble;

--- a/src/components/presentation/DetailPane.module.css
+++ b/src/components/presentation/DetailPane.module.css
@@ -1,0 +1,112 @@
+.DetailPane {
+  margin-bottom: 2em;
+  background: white;
+  clip: border-box;
+  margin-bottom: 1em;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  margin-left: 20px;
+  border-radius: 10px;
+  max-width: 1200px;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.01), 0 1px 2px rgba(0,0,0,0.033), 0 2px 8px rgba(0,0,0,0.033), 0 2px 16px rgba(0,0,0,0.033), 0 4px 32px rgba(0,0,0,0.066);
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  background-color: #EFEBFF;
+  background-color: #f6f4ff;
+  background-color: #f8f8ff;
+}
+
+.DetailTitle {
+  width: 100%;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+  padding: 5px 15px 10px 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 40px;
+}
+
+.DetailSubtitle {
+  display: block;
+  font-size: 0.9em;
+  margin-left: 1em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  height: 1.3em;
+  line-height: 1.3em;
+  margin-top: 0.3em;
+  margin-right: 2em;
+  width: 100%;
+}
+
+.DetailTitleColumns {
+  display: flex;
+  flex-direction: row;
+  align-content: center;  
+}
+
+.DetailLinkContainer {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+  white-space: nowrap;
+  width: calc(100% - 15em);
+}
+
+.DetailTitleColumns a {
+  color: black;
+  text-decoration: none;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+  "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",sans-serif;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.DetailTitleColumns a:hover {
+  color: #7E57FF;
+}
+
+.DetailButtons {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.DetailButton {
+  margin-top: -0.25em;
+  margin-right: 2em;
+}
+
+.DetailIcon {
+  margin-right: 0.5em;
+  font-size: 1.2em;
+  cursor: default;
+}
+
+.DetailContent {
+  font-size: 0.85em;
+  padding: 5px 15px 10px 15px;
+  width: calc(100%-30px);
+  max-width: 800px;
+  white-space: wrap;
+}
+
+.DetailPane img {
+  max-width: 100%;
+}
+
+.DetailPane code {
+  font-size: 0.9em;
+  white-space: pre-wrap;
+}
+
+.DetailPane h3 {
+  font-size: 1.1em;
+  font-weight: 600;
+}
+
+.DetailPane p>img {
+  margin-top: 1em;
+}

--- a/src/components/presentation/DetailPane.tsx
+++ b/src/components/presentation/DetailPane.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styles from './DetailPane.module.css';
+import Button from './Button';
+
+interface DetailPaneProps {
+  title: string;
+  titleUrl: string;
+  titleTip?: string;
+  subtitle?: string;
+  icon?: string;
+  isLoading?: boolean;
+  isEditing?: boolean;
+  onSave?: () => void;
+  onEditing?: (editing: boolean) => void;
+  children: React.ReactNode;
+}
+
+const DetailPane: React.FC<DetailPaneProps> = (props: DetailPaneProps)  => {
+
+  // Button is different depending on state
+  const button = () => {
+    if ( props.isEditing ) {
+      return (
+        <span className={styles.DetailButtons}>
+          <Button title='Cancel' size='medium' isSecondary={true} onClick={() => { props.onEditing?.(false) }}/>
+          <Button title='Save' size='medium' onClick={() => { props.onSave?.() }}/>
+        </span>
+      )
+    }
+    else {
+      return <Button title='Edit' size='medium' isSecondary={true} onClick={() => { props.onEditing?.(true) }}/>
+    }
+  }
+
+  // Render our HTML
+  return (
+    <div className={styles.DetailPane}>
+      <div className={styles.DetailTitle}>
+        <div className={styles.DetailTitleColumns}>
+          <span className={styles.DetailLinkContainer}>
+            <span className={styles.DetailIcon}>{props.icon}</span>
+            <a href={props.titleUrl} target='_blank' rel='noreferrer' title={props.titleTip}>
+              {props.title}
+            </a>
+            <span className={styles.DetailSubtitle}>{props.subtitle}</span>
+          </span>
+          <span className={styles.DetailButton}>{button()}</span>
+        </div>
+      </div>
+      <div className={styles.DetailContent}>{props.children}</div>
+    </div>
+  )
+}
+
+export default DetailPane;

--- a/src/components/presentation/GrowingText.module.css
+++ b/src/components/presentation/GrowingText.module.css
@@ -1,0 +1,37 @@
+
+.GrowingTextContainer {
+  display: grid;
+  margin-top: -2px;
+}
+
+.Input, 
+.Replica {
+  margin-top: 1em;
+  grid-area: 1 / 1 / 2 / 2;
+  padding-bottom: 1em;
+  font-size: 1em;
+}
+
+.Replica {
+  /* This is how textarea text behaves */
+  white-space: pre-wrap;
+
+  /* Hidden from view, clicks, and screen readers */
+  visibility: hidden;
+}
+
+textarea.Input {
+  font: inherit;
+  border: none;
+  overflow: hidden;
+  outline: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  resize: none;
+  margin-left: -2px;
+  width: 100%;
+  min-height: 1em;
+  background-color: rgba(0,0,0,0);
+}
+

--- a/src/components/presentation/GrowingText.tsx
+++ b/src/components/presentation/GrowingText.tsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect, useRef } from 'react';
+import styles from './GrowingText.module.css';
+
+interface GrowingTextProps {
+  text?: string;
+  placeholder?: string;
+  style?: any;
+  focusRequestedAt?: number;
+  clearRequestedAt?: number;
+  onChange?: (text: string) => void;
+}
+
+const GrowingText:React.FC<GrowingTextProps> = (props: GrowingTextProps) => {
+  
+  // Start our internal editable text with any raw text passed in
+  const [editableText, setEditableText] = useState(props.text || '');
+
+  // When text changes, update it
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setEditableText(event.target.value);
+    props.onChange?.(event.target.value);
+  }
+
+  // We need a reference to our textarea
+  const textAreaRef: any = useRef<HTMLTextAreaElement>();
+
+  // If the focus is requested, focus the textarea
+  useEffect(() => {
+    if ( props.focusRequestedAt && props.focusRequestedAt > 0 && textAreaRef.current ) {
+      textAreaRef?.current?.focus();
+      setTimeout(() => {
+        textAreaRef?.current?.scrollIntoView({behavior: "smooth", block: "center", inline: "center"});
+      }, 1000);
+    }
+  }, [props.focusRequestedAt])
+
+  // If a clear is requested, clear the text
+  useEffect(() => {
+    if ( props.clearRequestedAt ) {
+      setEditableText('');
+      if ( textAreaRef.current ) {
+       textAreaRef.current.value = '';
+      }
+    }
+  }, [props.clearRequestedAt]) 
+
+  return (
+    <div className={styles.GrowingTextContainer} style={props.style}>
+      <textarea 
+        ref={textAreaRef}
+        className={styles.Input} 
+        placeholder={props.placeholder}
+        onChange={handleChange}>
+        {editableText}
+      </textarea>
+      <div className={styles.Replica}>{`${editableText} `}</div>
+    </div>
+  )
+}
+
+export default GrowingText;

--- a/src/components/presentation/Listing.module.css
+++ b/src/components/presentation/Listing.module.css
@@ -25,20 +25,23 @@
 }
 
 .Listing[highlighted='true'] {
-  background-color: #EFEBFF;
-  /*transition: background-color 1s linear;*/
-}
-
-.Listing[highlighted='true']:hover {
-  background-color: #eae6fd;
+  box-shadow: inset 4px 0px 0px 0px rgba(126,87,255,1.0); 
 }
 
 .Listing[new='true'] {
   animation: glow 3s;
 }
 
-.Listing[blank='true']:hover {
+.Listing[editing='true']:hover {
   background-color: white;
+}
+
+.Listing[selecting='true'] {
+  background-color: #EFEBFF;
+}
+
+.Listing[selecting='true']:hover {
+  background-color: #eae6fd;
 }
 
 .Listing[dimmed='true'] .Link {
@@ -122,12 +125,12 @@
   cursor: pointer;
   max-width: 600px;
   margin-top: 2px;
-
 }
 
-.Link:hover {
+.Listing[linking='true'] .Link:hover {
   color: #7E57FF;
 }
+
 
 .Chips {
   margin-top: 0.5em;
@@ -167,14 +170,22 @@
   background: rgba(0,0,0,0);
 }
 
+.Buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+
 .Button {
   position: absolute;
-  right: 1em;
+  right: 2.1em;
+  top: 0.8em;
 }
 
 .Radio {
   position: absolute;
-  right: 8.2em;
+  right: 7.9em;
+  top: 0.8em;
 }
 
 .EnvironmentOptions {

--- a/src/components/presentation/Listing.tsx
+++ b/src/components/presentation/Listing.tsx
@@ -25,10 +25,13 @@ interface ListingProps {
   extra?: React.ReactNode;
   extras?: React.ReactNode[];
   isShowingActions?: boolean;
+  isShowingActionShortcuts?: boolean;
   isHighlighted?: boolean;
+  isSelected?: boolean;
   isDimmed?: Boolean;
   isNew?: boolean;
   isEditing?: boolean;
+  isCreating?: boolean;
   entity?: any;
   defaultCategory?: string;
   focusRequestedAt?: number;
@@ -37,12 +40,18 @@ interface ListingProps {
   onKey?(key: string, entity?: any): boolean;
   onFocus?(): void;
   onBlur?(): void;
+  onClick?(): void;
+  onEditing?(editing: boolean): void;
 }
 
 const Listing: React.FC<ListingProps> = (props) => {
 
   // Handle showing + hiding of actions strip
-  const handleIconClick = () => { props.onShowActions?.(!props.isShowingActions); }
+  const handleIconClick = (event) => { 
+    event.stopPropagation();
+    event.preventDefault();
+    props.onShowActions?.(!props.isShowingActions); 
+  }
 
   // Accept clicks on actions + trigger an update to the issue
   const handleActionClick = (action: ActionType) => {
@@ -53,7 +62,7 @@ const Listing: React.FC<ListingProps> = (props) => {
   }
 
   // Setup editing
-  const [editedTitle, setEditedTitle] = useState((props.title) || '');
+  const [editedTitle, setEditedTitle] = useState<string | undefined>((props.title) || '');
   const handleChangeTitle = (event: any) => {
     setEditedTitle(event.target.value);
   }
@@ -70,8 +79,9 @@ const Listing: React.FC<ListingProps> = (props) => {
   useEffect(() => { 
     if ( props.isEditing ) {
       setEditable(true);
+      setEditedTitle(props.title);
     }
-  }, [props.isEditing]);
+  }, [props.isEditing, props.title]);
 
   // When the focus epoc is upgraded, we'll focus on the input
   useEffect(() => {
@@ -84,11 +94,20 @@ const Listing: React.FC<ListingProps> = (props) => {
 
   // They clicked to create a new issue
   const handleClickCreate = () => {
-    if ( props.onUpdate ) {
-      props.onUpdate({ title: editedTitle, description: '', meta: { category: issueCategory, environment: issueEnvironment } });
+    if ( editedTitle ) {
+      props.onUpdate?.({ title: editedTitle, description: '', meta: { category: issueCategory, environment: issueEnvironment } });
+      setEditedTitle('');
+      setIssueEnvironment(undefined);
     }
-    setEditedTitle('');
-    setIssueEnvironment(undefined);
+  }
+
+  // They canceled or saved edits to an existing issue
+  const handleClickCancel = () => { props.onEditing?.(false); }
+  const handleClickSave = () => {
+    if ( editedTitle ) { 
+      props.onUpdate?.({ title: editedTitle, meta: {} }, props.entity);
+      props.onEditing?.(false);
+    }
   }
 
   // The clicked the issue category radio
@@ -98,17 +117,29 @@ const Listing: React.FC<ListingProps> = (props) => {
   }
 
   // When the user is moused over a listing, accept keyboard shortcuts
-  const handleKey = (key: string) => { props.onKey?.(key, props.entity) }
+  const handleKey = (key: string) => { 
+    if ( !props.isEditing && !props.isCreating ) {
+      props.onKey?.(key, props.entity) 
+    }
+  }
 
   // Handle key presses on the input
   const handleInputKeyPress = (event: any) => {
     if ( event.key === 'Enter' ) {
-      handleClickCreate();
+      if ( props.isCreating ) {
+        handleClickCreate();
+      }
+      else {
+        handleClickSave();
+      }
       inputRef.current?.blur();
     }
     else if ( event.key === 'Escape' ) {
       setEditedTitle('');
       inputRef.current?.blur();
+      if ( props.isEditing && !props.isCreating ) {
+        props.onEditing?.(false);
+      }
     }
   };
 
@@ -117,16 +148,28 @@ const Listing: React.FC<ListingProps> = (props) => {
   const handleInputFocus = () => { props.onFocus?.();  }
   const handleInputBlur = () => {  props.onBlur?.(); }
 
+  // If the issue is clicked, then we'll select that issue
+  const handleListingClick = () => {
+    props.onClick?.();
+  }
+
   // For bugs we'll prompt for environment
   const [issueEnvironment, setIssueEnvironment] = useState<EnvironmentType>();
 
   // These can change as we go
-  const divProps = { highlighted: `${props.isHighlighted}`, new: `${props.isNew}`, dimmed: `${props.isDimmed}`, actions: `${props.isShowingActions}` };
+  const divProps = { 
+    highlighted: `${props.isHighlighted}`, 
+    linking: `${props.url ? 'true' : 'false'}`,
+    selecting: `${props.isSelected}`,
+    new: `${props.isNew}`, 
+    dimmed: `${props.isDimmed}`, 
+    actions: `${props.isShowingActions}` 
+  };
 
   // Figure out what to put on the right column
   const extra = () => {
     if ( props.extras ) {
-      return <span className={styles.Extra}>
+      return <span className={styles.Extra} onClick={(event) => event.stopPropagation()}>
         { props.extras.map((extra: React.ReactNode, index: number) => {
             return <span className={styles.ExtraChild} key={index}>{extra}</span>
           })
@@ -134,7 +177,7 @@ const Listing: React.FC<ListingProps> = (props) => {
       </span>
     }
     else if ( props.extra ) {
-      return <span className={styles.Extra}>{ props.extra }</span>
+      return <span className={styles.Extra} onClick={(event) => event.stopPropagation()}>{ props.extra }</span>
     }
     else {
 
@@ -151,132 +194,191 @@ const Listing: React.FC<ListingProps> = (props) => {
     }
   }
 
-  // We have two main states of our issue row, 
-  // showing the listing, or showing actions
-  if ( props.isShowingActions ) {
-    return (<KeyWatcher onKey={handleKey}>
-              <div className={styles.Listing} {...divProps}>
-                <span className={styles.IconAndTitle}>
-                  <span className={styles.Close} onClick={handleIconClick} title="Click to close or press Escape">
-                    <IconX width='1.2em' height='1.2em'/>
+  // Generate our content with this big method
+  // This is begging to be turned into smaller components
+  const content = () => {
+
+    // We have two main states of our issue row, 
+    // showing the listing, or showing actions
+    if ( props.isShowingActions ) {
+      return (<div className={styles.Listing} {...divProps}>
+                  <span className={styles.IconAndTitle}>
+                    <span className={styles.Close} onClick={handleIconClick} title="Click to close or press Escape">
+                      <IconX width='1.2em' height='1.2em'/>
+                    </span>
+                    <Actions 
+                      actions={props.actions || []} 
+                      isShowingShortcuts={props.isShowingActionShortcuts} 
+                      onClickAction={handleActionClick}
+                    />
                   </span>
-                  <Actions actions={props.actions || []} onClickAction={handleActionClick}/>
-                </span>
-              </div>
-            </KeyWatcher>);
-  }
-  else {
-
-    // If we're editing this one
-    if ( props.isEditing ) {
-
-      // Should we display a button
-      const button = () => {
-        if ( editedTitle && editedTitle.length > 0 ) {
-          return <Button isSmall={true} 
-                         title='Create'
-                         onClick={handleClickCreate}/>
-        } 
-        return undefined;
-      }
-
-      // This lets us say what kind of issue it is when creating
-      const radio = () => {
-        if ( editedTitle && editedTitle.length > 0 ) {
-          return <Radio answers={[CATEGORY_FEATURE, CATEGORY_BUG]}
-                        selectedAnswer={issueCategory}
-                        onClickRadio={handleClickCategory}/>
-        }
-        else {
-          return undefined;
-        }
-      }
-
-      // Optionall,y we may show environments
-      const environmentOptions = () => {
-        if ( editedTitle && editedTitle.length > 0 && issueCategory === CATEGORY_BUG ) {
-
-          const options: OptionType[] = environments.map((environment: EnvironmentType) => {
-            return { title: environment.icon,
-                     name: environment.icon, 
-                     isSelected: (issueEnvironment?.name === environment.name), 
-                     isSelectable: true,
-                     isIconOnly: true,
-                     isExpandable: false, 
-                     onSelectOption: () => { setIssueEnvironment(environment); } };
-          });
-
-          return <span className={styles.EnvironmentOptions}><OptionChips options={[options]}/></span>;
-        }
-        else {
-          return undefined;
-        }
-      };
-
-      // Optionally show extras if we're not editing
-      const editingExtra = () => {
-        if ( !editedTitle?.length ) {
-          return extra();
-        }
-        return undefined;
-      };
-
-      // Custom input attributes
-      const inputAttributes = () => {
-        if ( isEditable ) {
-          return undefined;
-        }
-        else {
-          return { disabled: true }
-        }
-      }
-
-      return (
-        <div className={styles.Listing} {...{ blank: 'true' }} >
-          <span className={styles.IconAndTitle}>
-            <span 
-              className={styles.Icon} 
-              onClick={handleClickPlus}
-              title='Press n click to create a new issue'
-            >
-              ➕
-            </span>
-            <input className={styles.Input}
-                  ref={inputRef}
-                  placeholder={props.placeholder}
-                  value={editedTitle}
-                  onChange={handleChangeTitle}
-                  onKeyUp={handleInputKeyPress}
-                  onFocus={handleInputFocus}
-                  onBlur={handleInputBlur}
-                  {...inputAttributes()}
-            />
-            <span className={styles.Radio}>
-              {environmentOptions()}
-              {radio()}
-            </span>
-            <span className={styles.Button}>
-              {button()}
-            </span>
-          </span>
-          {editingExtra()}
-        </div>
-      );
+                </div>
+              );
     }
     else {
 
-      // This is our standard listing
-      return (<KeyWatcher onKey={handleKey}>
-                <div className={styles.Listing} {...divProps}>
-                  <span className={styles.IconAndTitle}>
-                    <span className={styles.Icon} title={`Press a or click for actions`} onClick={handleIconClick}>{props.icon}</span>
-                    <a className={styles.Link} href={props.url} target='_blank' rel='noopener noreferrer'>{props.title}</a>
-                  </span>
-                  {extra()}
-                </div>
-              </KeyWatcher>);
+      // If we're creating a new one
+      if ( props.isCreating ) {
+
+        // Should we display a button
+        const button = () => {
+          if ( editedTitle && editedTitle.length > 0 ) {
+            return <Button size='medium' 
+                          title='Save'
+                          onClick={handleClickCreate}/>
+          } 
+          return undefined;
+        }
+
+        // This lets us say what kind of issue it is when creating
+        const radio = () => {
+          if ( editedTitle && editedTitle.length > 0 ) {
+            return <Radio answers={[CATEGORY_FEATURE, CATEGORY_BUG]}
+                          selectedAnswer={issueCategory}
+                          onClickRadio={handleClickCategory}/>
+          }
+          else {
+            return undefined;
+          }
+        }
+
+        // Optionally, we may show environments
+        // Right now we're turning them off since 
+        // the feature needs to be more self-documenting
+        // before I feel it's ready for usage
+        const environmentOptions = () => {
+          return undefined;
+          /*
+          if ( editedTitle && editedTitle.length > 0 && issueCategory === CATEGORY_BUG ) {
+
+            const options: OptionType[] = environments.map((environment: EnvironmentType) => {
+              return { title: environment.icon,
+                      name: environment.icon, 
+                      isSelected: (issueEnvironment?.name === environment.name), 
+                      isSelectable: true,
+                      isIconOnly: true,
+                      isExpandable: false, 
+                      onSelectOption: () => { setIssueEnvironment(environment); } };
+            });
+
+            return <span className={styles.EnvironmentOptions}><OptionChips options={[options]}/></span>;
+          }
+          else {
+            return undefined;
+          }*/
+        };
+
+        // Optionally show extras if we're not editing
+        const editingExtra = () => {
+          if ( !editedTitle?.length ) {
+            return extra();
+          }
+          return undefined;
+        };
+
+        // Custom input attributes
+        const inputAttributes = () => {
+          if ( isEditable ) {
+            return undefined;
+          }
+          else {
+            return { disabled: true }
+          }
+        }
+
+        return (
+          <div className={styles.Listing} {...{ editing: 'true' }} >
+            <span className={styles.IconAndTitle}>
+              <span 
+                className={styles.Icon} 
+                onClick={handleClickPlus}
+                title='Press n click to create a new issue'
+              >
+                ➕
+              </span>
+              <input className={styles.Input}
+                    ref={inputRef}
+                    placeholder={props.placeholder}
+                    value={editedTitle}
+                    onChange={handleChangeTitle}
+                    onKeyUp={handleInputKeyPress}
+                    onFocus={handleInputFocus}
+                    onBlur={handleInputBlur}
+                    {...inputAttributes()}
+              />
+              <span className={styles.Radio}>
+                {environmentOptions()}
+                {radio()}
+              </span>
+              <span className={styles.Button}>
+                {button()}
+              </span>
+            </span>
+            {editingExtra()}
+          </div>
+        );
+      }
+      else if ( props.isEditing ) {
+
+        // We'll display some buttons
+        const button = () => {
+          if ( editedTitle && editedTitle.length > 0 ) {
+            return (
+              <span className={styles.Buttons}>
+                <Button size='medium' 
+                        title='Cancel'
+                        isSecondary={true}
+                        onClick={handleClickCancel}/>
+                <Button size='medium' 
+                        title='Save'
+                        onClick={handleClickSave}/>
+              </span>
+            )
+          } 
+          return undefined;
+        }
+
+        return (
+          <div className={styles.Listing} {...{ editing: 'true', selecting: `${props.isSelected}` }} >
+            <span className={styles.IconAndTitle}>
+              <span 
+                className={styles.Icon} 
+                onClick={handleClickPlus}
+                title='Press Enter to save or Escape to cancel'
+              >
+                ✍️
+              </span>
+              <input className={styles.Input}
+                    ref={inputRef}
+                    placeholder={props.placeholder}
+                    value={editedTitle}
+                    onChange={handleChangeTitle}
+                    onKeyUp={handleInputKeyPress}
+                    onFocus={handleInputFocus}
+                    onBlur={handleInputBlur}
+              />
+              <span className={styles.Button}>
+                {button()}
+              </span>
+            </span>
+          </div>
+        );
+      }
+      else {
+
+        // This is our standard listing
+        return (<div className={styles.Listing} {...divProps} onClick={handleListingClick}>
+                    <span className={styles.IconAndTitle}>
+                      <span className={styles.Icon} title={`Press a or click for actions`} onClick={handleIconClick}>{props.icon}</span>
+                      <a className={styles.Link} href={props.url} target='_blank' rel='noopener noreferrer'>{props.title}</a>
+                    </span>
+                    {extra()}
+                  </div>
+               );
+      }
     }
   }
+  return <KeyWatcher onKey={handleKey} disabled={props.isEditing || props.isCreating}>{content()}</KeyWatcher>
 }
 
 export default Listing;

--- a/src/components/presentation/Prompt.tsx
+++ b/src/components/presentation/Prompt.tsx
@@ -13,7 +13,7 @@ const Prompt: React.FC<PromptProps> = (props) => {
     <div className={styles.Prompt}>
       <span className={styles.Options}>{props.children}</span>
       <span className={styles.Button}>
-        <Button title='Done' isSmall={true} onClick={() => props.onClosePrompt?.()}/>
+        <Button title='Done' size='medium' onClick={() => props.onClosePrompt?.()}/>
       </span>
     </div>
 

--- a/src/data/actions.ts
+++ b/src/data/actions.ts
@@ -24,6 +24,9 @@ export const updateForAction = (action: any, labelToRemove: any) => {
       return { state_event: 'close', remove_labels: removeWhenClosing.join(',') };
     }
   } 
+  else if ( action.icon === '✍️' ) {
+    return { isEditingTitle: true };
+  }
   else if ( action.icon === '🗑' ) {
     return { delete: true };
   }
@@ -47,37 +50,41 @@ const deleteAction = { icon: '🗑', name: 'Delete', shortcut: 'x', isConfirmabl
 // Figure out our actions based on our state
 const actionsForIcon: any = { 
   '✅': [{ icon: '✅', name: 'Complete', shortcut: 'C', isUndo: true },
+         { icon: '✍️', name: 'Edit', shortcut: 'e'},
          deleteAction],
   '⏳': [{ icon: '✅', name: 'Complete', shortcut: 'c'},
          { icon: '👓', name: 'Review', shortcut: 'r'},
          { icon: '⏳', name: 'Doing', shortcut: 'D', isUndo: true },
          /*{ icon: '⏸', name: 'Paused'},*/
          { icon: '🛑', name: 'Blocked'},
+         { icon: '✍️', name: 'Edit', shortcut: 'e'},
          deleteAction],
   '👓': [{ icon: '✅', name: 'Complete', shortcut: 'c'},
          { icon: '👓', name: 'Review', shortcut: 'R', isUndo: true },
          { icon: '⏳', name: 'Doing', shortcut: 'd'},
          { icon: '🛑', name: 'Blocked'},
+         { icon: '✍️', name: 'Edit', shortcut: 'e'},
          deleteAction],
   '⏸': [{ icon: '✅', name: 'Complete', shortcut: 'c'},
          { icon: '⏳', name: 'Doing', shortcut: 'd'},
          { icon: '⏸', name: 'Paused', isUndo: true },
          { icon: '🛑', name: 'Blocked'},
-         ...priorities,
+         { icon: '✍️', name: 'Edit', shortcut: 'e'},
          deleteAction],
   '🛑': [{ icon: '✅', name: 'Complete', shortcut: 'c'},
          { icon: '⏳', name: 'Doing', shortcut: 'd'},
          { icon: '🛑', name: 'Blocked', isUndo: true },
-         ...priorities,
+         { icon: '✍️', name: 'Edit', shortcut: 'e'},
          deleteAction],
   '🧺': [...priorities, 
-         deleteAction],
+        { icon: '✍️', name: 'Edit', shortcut: 'e'},
+        deleteAction],
 
   /* Handle default case */
   '❓': [{ icon: '✅', name: 'Complete', shortcut: 'c'},
-         { icon: '👓', name: 'Review', shortcut: 'r'},
          { icon: '⏳', name: 'Doing', shortcut: 'd'},
          ...priorities,
+         { icon: '✍️', name: 'Edit', shortcut: 'e'},
          deleteAction ],
 
   /* Handle case for each priority */

--- a/src/data/polling.ts
+++ b/src/data/polling.ts
@@ -4,10 +4,11 @@
 export const polling: any = {
   frequency: {
     allIssue: 10000,
+    issueDetail: 10000,
     unassignedIssueCount: 32250,
     bugCount: 33500,
     epics: 123400,
-    pullRequests: (15 * 60000) + 4000
+    pullRequests: (15 * 60000) + 4000,
   },
   period: {
     changedIssue: 10000

--- a/src/data/priorities.ts
+++ b/src/data/priorities.ts
@@ -5,7 +5,7 @@ export const priorities: Priority[] = [
   { icon: '⭐️', name: 'P1', level: 1, shortcut: '1' },
   { icon: '🙏', name: 'P2', level: 2, shortcut: '2' },
   { icon: '🤷🏻‍♀️', name: 'P3', level: 3, shortcut: '3' },
-  { icon: '🛎', name: 'Triage', level: 1 },
+  { icon: '🛎', name: 'Triage', level: 1, shortcut: 't' },
 ];
 
 export const labelFromPriority = (priority: Priority) => `${priority.name} ${priority.icon}`;

--- a/src/data/queries/gitlab/graphql.ts
+++ b/src/data/queries/gitlab/graphql.ts
@@ -118,6 +118,55 @@ export const EPIC_WITH_ISSUES_FRAGMENT = gql`
   ${ISSUE_ONLY_FRAGMENT}
 `;
 
+export const ISSUE_DETAIL = gql`
+  query GetIssueDetail($id: IssueID!) {
+    issue(id: $id) {
+      id,
+      iid,
+      projectId,
+      title,
+      state,
+      webUrl,
+      webPath,
+      dueDate,
+      humanTimeEstimate,
+      labels {
+          nodes {
+            id,
+            title
+          }
+      },
+      milestone {
+        id,
+        title
+      },
+      assignees {
+        nodes {
+          username
+        }
+      },
+      author {
+        name,
+        username
+      },
+      createdAt,
+      updatedAt,
+      description,
+      notes {
+        nodes {
+          author {
+            name,
+            username
+          },
+          createdAt,
+          body,
+          system
+        }
+      }
+    }
+  }
+`;
+
 export const ALL_ISSUES = gql`
   query GetAllUserIssues($username: String!, $milestones: [String], $labels: [String], $fullPath: ID!) {
     group(fullPath: $fullPath) {

--- a/src/data/queries/gitlab/rest.ts
+++ b/src/data/queries/gitlab/rest.ts
@@ -48,6 +48,15 @@ export const MOVE_ISSUE = gql`
     }
 `;
 
+export const CREATE_NOTE = gql`
+  mutation CreateNote($projectId: ID!, $issueId: ID!, $input: Any!) {
+    createNote(projectId: $projectId, issueId: $issueId, input: $input)
+      @rest(type: "Note", path: "/projects/{args.projectId}/issues/{args.issueId}/notes", method: "POST") {
+        NoResponse
+    }
+  }
+`;
+
 export const SUBGROUPS = gql`
   query GetSubgroups($groupId: ID!) {
     subgroups(groupId: $groupId) 

--- a/src/data/queries/local.ts
+++ b/src/data/queries/local.ts
@@ -7,9 +7,9 @@ export const IS_LOGGED_IN = gql`
 `;
 
 export const FILTER = gql`query Filter { filter @client }`;
-
 export const EXTRA_COLUMN = gql`query ExtraColumn { extraColumn @client }`;
 export const EXTRA_DIFF_COLUMN = gql`query ExtraDiffColumn { extraDiffColumn @client }`;
+export const SELECTED_ISSUE = gql`query SelectedIssue { selectedIssueId @client }`;
 
 // Local queries
 export const localTypedefs = gql`
@@ -25,5 +25,6 @@ export const localTypedefs = gql`
     filter: Filter!
     extraColumn: String!
     extraDiffColumn: String!
+    selectedIssueId: String
   }
 `;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -126,7 +126,9 @@ export interface Issue {
   epic?: any;
   author?: any;
   assignees?: any;
+  notes?: any;
   state?: string;
+  description?: string;
   milestone?: Milestone;
   humanTimeEstimate?: string;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import Connection from './components/graphql/Connection';
 
 // Static Assets
 import { loadFonts } from './setup/fonts';
+import { setupTimeFormatting } from './setup/time';
 import './index.css';
 
 // State Management and Offline Support
@@ -17,6 +18,9 @@ import * as serviceWorker from './setup/serviceWorker';
 
 // Fonts
 loadFonts();
+
+// Setup time formatting
+setupTimeFormatting();
 
 // Was there a route the user was trying to go to?
 const afterSlash:string = window.location.href.split('/').slice(-1)[0].split('?')[0];

--- a/src/setup/time.js
+++ b/src/setup/time.js
@@ -1,0 +1,8 @@
+import TimeAgo from 'javascript-time-ago'
+import en from 'javascript-time-ago/locale/en.json'
+import ru from 'javascript-time-ago/locale/ru.json'
+
+export const setupTimeFormatting = () => {
+  TimeAgo.addDefaultLocale(en)
+  TimeAgo.addLocale(ru)
+}


### PR DESCRIPTION
- You can now select issues (they'll highlight purple, which was previously reserved for in progress issues)
- Issues currently in progress are now denoted through a purple bookmark on the left edge
- When selecting an issue, a details pane will appear
- You can see the description, and any chat entries in the details pane
- You can also edit the description and post new chat entries
- You can now edit titles on the issue list by pressing `e` or selecting Edit from the actions menu
- Various small fixes for keyboard interactivity