### PR TITLE
Some minor keyboard fixes for Issues #27 and #28

### DIFF
--- a/src/components/graphql/Issue.tsx
+++ b/src/components/graphql/Issue.tsx
@@ -29,11 +29,14 @@ import { environmentFromLabelNames } from 'data/environments';
 import { resolutionsFromLabelNames } from 'data/resolutions';
 import { flagsFromLabelNames } from 'data/flags';
 import { organization } from 'data/customize';
+import { BooleanValueNode } from 'graphql';
 
 interface IssueProps {
   issue?: IssueType;
   isCreating?: boolean;
   isEditing?: boolean;
+  isShowingActions?: boolean;
+  isShowingActionShortcuts?: boolean;
   extraColumn?: string;
   milestone?: MilestoneType,
   milestones?: MilestoneType[],
@@ -45,6 +48,7 @@ interface IssueProps {
   focusRequestedAt?: number;
   onUpdateIssue?(update: any, issue?: IssueType): void;
   onEditingIssue?(editing: boolean, issue?: IssueType): void;
+  onShowActions?(isShowing: boolean, isUsingKeyboard: boolean, issue?: IssueType): void;
   onNeedsKeyboard?(isNeeded: boolean): void;
   onKey?(key: string): boolean;
 }
@@ -127,10 +131,6 @@ const Issue: React.FC<IssueProps> = (props) => {
   // Ask the user for more info if they open or close a bug
   const [needsResolution, setNeedsResolution] = useState(false);
 
-  // Are we showing the actions menu?
-  const [showActions, setShowActions] = useState(false);
-  const [showActionShortcuts, setShowActionShortcuts] = useState(false);
-
   // When the issue is created, trigger a prompt to ask for enviromment
   /*
   useEffect(() => {
@@ -179,8 +179,7 @@ const Issue: React.FC<IssueProps> = (props) => {
     }
 
     // Clear the actions menu
-    setShowActions(false);
-    setShowActionShortcuts(false);
+    props.onShowActions?.(false, false, issue);
   }
 
   // Handle a key 
@@ -225,14 +224,17 @@ const Issue: React.FC<IssueProps> = (props) => {
       // Toggle showing the actions strip
       // and if we get there with the keyboard shortcut
       // then show other keyboard shortcuts
-      if ( !showActions ) { 
-        setShowActions(true);
-        setShowActionShortcuts(true);
+      if ( !props.isShowingActions ) { 
+        props.onShowActions?.(true, true, issue);
       }
       else {
-        setShowActions(false);
-        setShowActionShortcuts(false);
+        props.onShowActions?.(false, true, issue);
       }
+      return true;
+    }
+    else if ( key === 'Escape' && props.isShowingActions ) {
+      props.onShowActions?.(false, true, issue);
+      return true;
     }
 
     // No keys matched so use default handling in the Card, and then in the Listing
@@ -342,9 +344,9 @@ const Issue: React.FC<IssueProps> = (props) => {
             onUpdate={handleUpdate}
             onKey={handleKey}
             focusRequestedAt={focusRequestedAt}
-            isShowingActions={showActions}
-            isShowingActionShortcuts={showActionShortcuts}
-            onShowActions={(show) => { setShowActions(show); setShowActionShortcuts(false); }}
+            isShowingActions={props.isShowingActions}
+            isShowingActionShortcuts={props.isShowingActionShortcuts}
+            onShowActions={(show) => { props.onShowActions?.(show, false, issue) }}
             onEditing={(editing: boolean) => { handleEditing(editing)}}
             onFocus={() => props.onNeedsKeyboard?.(true)}
             onBlur={() => props.onNeedsKeyboard?.(false)}

--- a/src/components/presentation/DetailPane.module.css
+++ b/src/components/presentation/DetailPane.module.css
@@ -90,7 +90,9 @@
   padding: 5px 15px 10px 15px;
   width: calc(100%-30px);
   max-width: 800px;
-  white-space: wrap;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .DetailPane img {
@@ -109,4 +111,10 @@
 
 .DetailPane p>img {
   margin-top: 1em;
+}
+
+@media only screen and (max-width: 1600px) {
+  .DetailPane {
+    display: none !important;
+  } 
 }

--- a/src/components/presentation/KeyWatcher.tsx
+++ b/src/components/presentation/KeyWatcher.tsx
@@ -21,18 +21,33 @@ const KeyWatcher: React.FC<KeyWatcherProps> = (props) => {
   // that we can reliably remove from the window when the mouse leaves
   // (even if the react component re-renders)
   const handleKeyPress = useCallback((event: any) => { handleKeyRef.current(event.key); }, []);
+  const handleKeyDown = useCallback((event: any) => { 
+    // Only key up and key down get special keys (not key press)
+    if ( event.key === 'Escape' || event.key?.indexOf('Arrow') >= 0 ) {
+      handleKeyRef.current(event.key);
+    }
+  }, []);
+
+  // When the user mouses over the element, start listening for keyboard shortcuts
+  // We listen for onKeyUp to catch the escape key
   const handleMouseEnter = () => {
-    document.removeEventListener('keyup', handleKeyPress, true);
-    document.addEventListener('keyup', handleKeyPress, true);
+    document.removeEventListener('keypress', handleKeyPress, true);
+    document.removeEventListener('keydown', handleKeyDown, true);
+    document.addEventListener('keypress', handleKeyPress, true);
+    document.addEventListener('keydown', handleKeyDown, true);
   }
   const handleMouseLeave = () => {
-    document.removeEventListener('keyup', handleKeyPress, true);
+    document.removeEventListener('keypress', handleKeyPress, true);
+    document.removeEventListener('keydown', handleKeyDown, true);
   }
 
   // If this element is destroyed, then remove the event listener
   useEffect(() => {
-    return () => { document.removeEventListener('keyup', handleKeyPress, true); }
-  }, [handleKeyPress]);
+    return () => { 
+      document.removeEventListener('keypress', handleKeyPress, true); 
+      document.removeEventListener('keydown', handleKeyDown, true); 
+    }
+  }, [handleKeyPress, handleKeyDown]);
 
   return (
     <div className={props.className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>

--- a/src/components/presentation/KeyWatcher.tsx
+++ b/src/components/presentation/KeyWatcher.tsx
@@ -29,7 +29,7 @@ const KeyWatcher: React.FC<KeyWatcherProps> = (props) => {
   }, []);
 
   // When the user mouses over the element, start listening for keyboard shortcuts
-  // We listen for onKeyUp to catch the escape key
+  // We listen for onKeyDown to catch the escape key
   const handleMouseEnter = () => {
     document.removeEventListener('keypress', handleKeyPress, true);
     document.removeEventListener('keydown', handleKeyDown, true);

--- a/src/components/presentation/KeyWatcher.tsx
+++ b/src/components/presentation/KeyWatcher.tsx
@@ -22,16 +22,16 @@ const KeyWatcher: React.FC<KeyWatcherProps> = (props) => {
   // (even if the react component re-renders)
   const handleKeyPress = useCallback((event: any) => { handleKeyRef.current(event.key); }, []);
   const handleMouseEnter = () => {
-    window.removeEventListener('keypress', handleKeyPress, true);
-    window.addEventListener('keypress', handleKeyPress, true);
+    document.removeEventListener('keyup', handleKeyPress, true);
+    document.addEventListener('keyup', handleKeyPress, true);
   }
   const handleMouseLeave = () => {
-    window.removeEventListener('keypress', handleKeyPress, true);
+    document.removeEventListener('keyup', handleKeyPress, true);
   }
 
   // If this element is destroyed, then remove the event listener
   useEffect(() => {
-    return () => { window.removeEventListener('keypress', handleKeyPress, true); }
+    return () => { document.removeEventListener('keyup', handleKeyPress, true); }
   }, [handleKeyPress]);
 
   return (

--- a/src/components/presentation/Listing.tsx
+++ b/src/components/presentation/Listing.tsx
@@ -86,7 +86,6 @@ const Listing: React.FC<ListingProps> = (props) => {
   // When the focus epoc is upgraded, we'll focus on the input
   useEffect(() => {
     if ( props.focusRequestedAt && props.focusRequestedAt > 0 ) {
-      console.log('Focus requested at', props.focusRequestedAt);
       inputRef?.current?.focus();
       inputRef?.current?.scrollIntoView({behavior: "smooth", block: "center", inline: "center"});
     }


### PR DESCRIPTION
- Closes issues #27 and #28 
- Showing actions is now mutually exclusive to one listing per card
- Escape and arrow keys are supported on issue listings
