### PR TITLE
Support for deployment from M1 Macs with Apple Silicon

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
 docker-compose -f docker-compose.prod.yml up -d --build
 
 GCP_PROJECT=$(gcloud config get-value project)

--- a/scripts/setup/0-initial.sh
+++ b/scripts/setup/0-initial.sh
@@ -1,0 +1,8 @@
+gcloud config set project planner-XX
+gcloud config set compute/zone us-west4-a 
+
+# Get kubectl connected to our cluster
+# please rename based on actual name of cluster
+export CLUSTER_NAME=planner-cluster-XX
+kubectl config set-cluster ${GCP_PROJECT_ID}
+kubectl config gcloud container clusters get-credentials ${GCP_PROJECT_ID}

--- a/scripts/setup/1-gcp.sh
+++ b/scripts/setup/1-gcp.sh
@@ -1,6 +1,3 @@
-gcloud config set project planner-XX
-gcloud config set compute/zone us-west4-a 
-
 gcloud compute addresses create planner-ip  --global
 gcloud compute networks create planner
 gcloud compute firewall-rules create https --allow=tcp:443 --network planner --description="Allow traffic on TCP port 443"   


### PR DESCRIPTION
• Added default linux/arm64 architecture for building docker containers
• Fixes a problem where local images were compiled for Apple Silicon and couldn't run on Intel silicon in the cloud
• Added new initial script for first time setup on new development laptops that didn't create the original cluster