### PR TITLE
Fixed problem where issues in Triage for individuals were not appearing

### DIFF
--- a/src/components/graphql/UserIssues.tsx
+++ b/src/components/graphql/UserIssues.tsx
@@ -217,7 +217,8 @@ const UserIssues: React.FC<UserIssuesProps> = (props: UserIssuesProps) => {
   }
 
   // Figure out title and where it goes if you click iot
-  const userUrl: string = `https://gitlab.com/${organization}/${props.project}/-/issues?scope=all&utf8=%E2%9C%93&assignee_username[]=${props.username}&milestone_title=${props.milestone.title}`
+  const milestoneTitleForGitLab = props.milestone.title === 'none' ? 'None' : props.milestone.title
+  const userUrl: string = `https://gitlab.com/${organization}/${props.project}/-/issues?scope=all&utf8=%E2%9C%93&assignee_username[]=${props.username}&milestone_title=${milestoneTitleForGitLab}`
 
   // Keep track of which issue we're editing (only allow 1 at a time)
   const [editingIssueId, setEditingIssueId] = useState<number | null>(null);

--- a/src/data/queries/gitlab/graphql.ts
+++ b/src/data/queries/gitlab/graphql.ts
@@ -204,7 +204,7 @@ export const ALL_PROJECT_ISSUES = gql`
 
 export const OPEN_ISSUES_NO_MILESTONE = gql`
   query GetOpenUserIssuesNoMilestone($username: String!, $labels: [String], $fullPath: ID!) {
-    project(fullPath: $fullPath) {
+    group(fullPath: $fullPath) {
       name,
       issues (assigneeUsernames: [$username], 
               milestoneWildcardId: NONE,


### PR DESCRIPTION
- To test, assign an issue from the Requests tab with no milestone to a user
- The issue should show up in the Triage section within the user's page