### PR TITLE
Hour statistics are now rounded

### DIFF
--- a/src/data/stats.ts
+++ b/src/data/stats.ts
@@ -38,15 +38,15 @@ const isEstimateInDays = (value: string | undefined) => {
 const estimateInHours = (value: string | undefined) => {
   if ( value ) {
     if ( isEstimateInHours(value) ) {
-      return parseFloat(value);
+      return Math.ceil(parseFloat(value));
     }
     else if ( isEstimateInMinutes(value) ) {
-      return parseFloat(value) / 60;
+      return Math.ceil(parseFloat(value) / 60);
     }
     else if ( isEstimateInDays(value) ) {
-      return parseFloat(value) * 24;
+      return Math.ceil(parseFloat(value) * 24);
     }
-    return parseFloat(value);
+    return Math.ceil(parseFloat(value));
   }
   return 0;
 }


### PR DESCRIPTION
Previously, decimal hours would be shown, and there could be enough significant digits (like 0.666666667) that it would overflow the area for the stats.  Now, they are rounded to the next hour.