### PR TITLE
Fixes to responsive layout and keyboard shortcut handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "development": "NODE_ENV=development concurrently --kill-others \"npm run client\" \"npm run server\"",
     "production": "npm run build && NODE_ENV=production npm run server",
     "server": "node server/server.js",
-    "client": "react-scripts start",
+    "client": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/components/graphql/IssueDetail.tsx
+++ b/src/components/graphql/IssueDetail.tsx
@@ -40,7 +40,15 @@ const IssueDetail: React.FC<IssueDetailProps> = (props) => {
 
   // Transformations for links and images 
   const transformLinkUri = (href, children, title) => href?.indexOf('://') > 0 ? href : `https://gitlab.com/${href}`;
-  const transformImageUri = (src, alt, title) => `https://gitlab.com/${organization}/${projectName}${src}`;
+  const transformImageUri = (src, alt, title) => {
+    if ( src.includes('https://') ) {
+      return src
+    }
+    else
+    {
+      return `https://gitlab.com/${organization}/${projectName}${src}`
+    }
+  }
 
   // Filter out the user notes (not the system messages)
   const userNotes = issue?.notes?.nodes?.filter(note => !note.system)

--- a/src/components/presentation/Arena.module.css
+++ b/src/components/presentation/Arena.module.css
@@ -5,24 +5,53 @@
 }
 
 .MainPane {
-  min-width: 1224px;
+  min-width: 1046px;
+  width: 1046px;
 }
 
+/* Large screen case and default behavior */
 .DetailPane {
   position: fixed;
-  left: 1220px;
   flex-direction: column;
-  width: calc(100vw - 1240px);
+  left: 1040px;
+  width: calc(100vw - 1056px);
+  max-width: 1024px;
   height: calc(100vh - 7em);
 }
 
-@media only screen and (max-width: 1440px) {
+/* Tiny screen case */
+@media only screen and (max-width: 1280px) {
+  .DetailPane { 
+    left: 606px !important;
+    width: calc(100vw - 620px) !important;
+    min-width: 440px;
+  } 
+}
+
+/* Smaller screen case */
+@media only screen and (min-width: 1281px) and (max-width: 1440px) {
   .MainPane {
     min-width: 1046px;
     max-width: 1046px;
+    width: 1046px;
   }
   .DetailPane {
     left: 1040px;
     width: calc(100vw - 1056px);
   }
 }
+
+/* Medium screen case */
+@media only screen and (min-width: 1441px) and (max-width: 2000px) {
+  .MainPane {
+    min-width: 1046px;
+    max-width: 1046px;
+    width: 1046px;
+  }
+  .DetailPane {
+    left: 1040px;
+    width: calc(100vw - 1056px);
+  }
+}
+
+

--- a/src/components/presentation/DetailPane.module.css
+++ b/src/components/presentation/DetailPane.module.css
@@ -31,7 +31,7 @@
   display: block;
   font-size: 0.9em;
   margin-left: 1em;
-  text-overflow: ellipsis;
+  text-overflow: ellipsis; 
   white-space: nowrap;
   overflow: hidden;
   height: 1.3em;
@@ -40,6 +40,14 @@
   margin-right: 2em;
   width: 100%;
 }
+
+/* If things get narrow enough, don't try to show title */
+@media only screen and (min-width: 1281px) and (max-width: 1440px) {
+  .DetailSubtitle {
+    display: none;
+  }
+}
+
 
 .DetailTitleColumns {
   display: flex;
@@ -113,8 +121,3 @@
   margin-top: 1em;
 }
 
-@media only screen and (max-width: 1280px) {
-  .DetailPane {
-    display: none !important;
-  } 
-}

--- a/src/components/presentation/KeyWatcher.tsx
+++ b/src/components/presentation/KeyWatcher.tsx
@@ -20,11 +20,18 @@ const KeyWatcher: React.FC<KeyWatcherProps> = (props) => {
   // useCallback is important here because it creates a durable event handler
   // that we can reliably remove from the window when the mouse leaves
   // (even if the react component re-renders)
-  const handleKeyPress = useCallback((event: any) => { handleKeyRef.current(event.key); }, []);
+  const handleKeyPress = useCallback((event: any) => { 
+    if ( !window['ignoreKeyboardShortcuts'] ) {
+      handleKeyRef.current(event.key); 
+    }
+  }, []);
+
+  // Only key up and key down get special keys (not key press)
   const handleKeyDown = useCallback((event: any) => { 
-    // Only key up and key down get special keys (not key press)
-    if ( event.key === 'Escape' || event.key?.indexOf('Arrow') >= 0 ) {
-      handleKeyRef.current(event.key);
+    if ( !window['ignoreKeyboardShortcuts'] ) {
+      if ( event.key === 'Escape' || event.key?.indexOf('Arrow') >= 0 ) {
+        handleKeyRef.current(event.key);
+      }
     }
   }, []);
 

--- a/src/components/presentation/Listing.module.css
+++ b/src/components/presentation/Listing.module.css
@@ -150,6 +150,7 @@
   text-align: right;
   display: flex;
   flex-direction: row;
+  white-space: nowrap;
 }
 
 .ExtraChild + .ExtraChild {
@@ -161,7 +162,7 @@
 
 .Input {
   border: none;
-  width: 50em;
+  width: 35em;
   outline: none;
   font-size: 1em;
   display: flex;
@@ -201,16 +202,6 @@
     max-width: 400px;
   }
 }
-
-@media only screen and (max-width: 1440px) {
-  .Link {
-    max-width: 500px;
-  }
-  .Input {
-    max-width: 700px;
-  }
-}
-
 
 @media only screen and (max-width: 480px) {
   .Chips {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { Filter } from './data/types';
 import { vendors, requestVendorAccessToken, isStateTokenValid } from './data/vendors';
 import { teams } from './data/teams';
 import { currentYear, currentQuarter, currentSprint } from './data/milestones';
+import { setupKeyboardFiltering } from './setup/keyboard';
 import * as serviceWorker from './setup/serviceWorker';
 
 // Fonts
@@ -21,6 +22,10 @@ loadFonts();
 
 // Setup time formatting
 setupTimeFormatting();
+
+// Setup keyboard filtering - adds extra properties 
+// to suppress shortcuts when a field is focused
+setupKeyboardFiltering();
 
 // Was there a route the user was trying to go to?
 const afterSlash:string = window.location.href.split('/').slice(-1)[0].split('?')[0];


### PR DESCRIPTION
Fixes include:

- Keyboard shortcuts were triggering inadvertently when typing into a field if the mouse hovered over a UI element that accepts keyboard shortcuts.  This is now filtered via global detection of focus events.
- Detail pane now scales appropriately, and can always show (overlapping extra fields when screen is very small)
- The schedule could previously wrap on some screen sizes, making things look all caddywumpus
- The statistics could pop past the end of the card, breaking the physical reality of the UI
- There's a workaround for a SSL issue on new versions of Node after 16 that affects running locally
