### PR TITLE
Fix for keyboard shortcuts being applied when typing something

### DIFF
--- a/src/setup/keyboard.ts
+++ b/src/setup/keyboard.ts
@@ -1,0 +1,9 @@
+
+// Set a flag that allows the app to know whenever we're typing in a field anywhere
+// so that we can ignore keyboard shortcuts that happen on mouseover of various elements in the page
+const setupKeyboardFiltering = () => {
+  window.addEventListener('focusin', () => { window['ignoreKeyboardShortcuts'] = true })
+  window.addEventListener('focusout', () => { window['ignoreKeyboardShortcuts'] = false })
+}
+
+export { setupKeyboardFiltering }


### PR DESCRIPTION
When typing into a title field, description field, chat message, or searching for a milestone – the keyboard shortcuts could be triggered for a task, changing the state of that task inadvertently.

This has now been fixed by disabling shortcuts globally when focused on a typeable field.