### PR TITLE
Tickets option in filter bar selection now behaves correctly

### DIFF
--- a/src/components/graphql/Diffs.tsx
+++ b/src/components/graphql/Diffs.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Card from '../presentation/Card';
+import Listing from '../presentation/Listing';
 import Diff from './Diff';
 import { Option, OptionChoice, Diff as DiffType, Team } from 'data/types';
 import { extraDiffColumns } from 'data/extras';
@@ -122,6 +123,7 @@ const Diffs: React.FC<DiffsProps> = (props: DiffsProps) => {
             isLoading={false}
             option={cardOption}>
         {
+          reviewDiffs.length === 0 ? <Listing icon='⏳' title='Loading, this may take a minute...' />:
           reviewDiffs.map((diff: DiffType) => 
             <Diff key={diff.number} diff={diff} extraColumn={extraQuery.data?.extraDiffColumn}/>
           )

--- a/src/components/presentation/FilterBar.tsx
+++ b/src/components/presentation/FilterBar.tsx
@@ -83,7 +83,7 @@ const FilterBar:React.FC<FilterBarProps> = (props: FilterBarProps) => {
       name: username, 
       isRadio: true,
       isSelected: username === filter?.username,
-      onSelectOption: onSelectUser 
+      onSelectOption: onSelectUser
     };
   }
 
@@ -139,7 +139,13 @@ const FilterBar:React.FC<FilterBarProps> = (props: FilterBarProps) => {
   //const epicsOption = {...optionForUser('epics'), title: 'Epics'};
 
   //const roadmapOption: Option = {...optionForMode('roadmap'), icon: 'roadmap'};
-  const ticketsOption: Option = {...optionForMode('tickets'), icon: 'tickets'};
+  const ticketsOption: Option = { 
+            name: 'tickets', 
+            isRadio: true,
+            icon: 'tickets',
+            isSelected: filter?.username !== 'diffs' && filter?.username !== 'links',
+            onSelectOption: (option: Option) => onSelectUser({ name: 'none' })
+          };
   const linksOption: Option = {...optionForMode('links'), icon: 'link'};
   const diffsOption: Option = {...optionForMode('diffs'), icon: 'code'};
   const modeOptions: Option[] = [ticketsOption, diffsOption, linksOption];


### PR DESCRIPTION
Fixed an issue where the checkmark option (tickets) wasn't being selected when selecting a user.  Also, it would go to the URL `\tickets` when clicked when it should go to `\none` to show all requests without an assigned owner.

In the future, I'd like to clean this up and have a two tier URL, with `mode\user`, allowing for us to filter roadmap by users too.