### PR TITLE
Updated to latest packages + made audit production only

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/package.json
+++ b/package.json
@@ -3,23 +3,29 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.7.17",
+    "@apollo/client": "^3.11.8",
+    "@storybook/react": "^8.3.3",
     "apollo-link": "^1.2.14",
     "apollo-link-rest": "^0.9.0",
-    "concurrently": "^8.2.0",
-    "express": "^4.18.2",
-    "graphql": "^15.3.0",
+    "concurrently": "^9.0.1",
+    "express": "^4.21.0",
+    "graphql": "^15.8.0",
     "graphql-anywhere": "^4.2.8",
-    "http-proxy-middleware": "^2.0.6",
-    "javascript-time-ago": "^2.5.9",
+    "http-proxy-middleware": "^3.0.2",
+    "javascript-time-ago": "^2.5.11",
     "node-fetch": "latest",
-    "qs": "^6.11.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "qs": "^6.13.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-markdown": "^8.0.7",
-    "react-time-ago": "^7.2.1",
+    "react-time-ago": "^7.3.3",
     "relative-time-format": "^1.1.6",
-    "remark-gfm": "^3.0.1"
+    "remark-gfm": "^4.0.0",
+    "storybook": "^8.3.3",
+    "svgo": "^3.3.2"
+  },
+  "resolutions": {
+    "react-refresh": "0.14.2"
   },
   "scripts": {
     "start": "tsc && npm run development",
@@ -34,7 +40,7 @@
     "docker": "docker-compose -f docker-compose.prod.yml up -d --build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "audit": "npm audit --production"
+    "postinstall": "npm audit --omit=dev"
   },
   "engines": {
     "node": "18.x"
@@ -76,31 +82,19 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7",
-    "@storybook/addon-essentials": "^7.4.6",
-    "@storybook/addon-interactions": "^7.4.6",
-    "@storybook/addon-links": "^7.4.6",
-    "@storybook/addon-onboarding": "^1.0.8",
-    "@storybook/blocks": "^7.4.6",
-    "@storybook/preset-typescript": "^3.0.0",
-    "@storybook/preset-create-react-app": "^7.4.6",
-    "@storybook/react": "^7.4.6",
-    "@storybook/react-webpack5": "^7.4.6",
-    "@storybook/testing-library": "^0.2.2",
-    "@types/express": "^4.17.17",
-    "@types/jest": "^29.5.3",
-    "@types/react": "^18.2.17",
-    "@types/react-dom": "^18.2.7",
-    "babel-plugin-module-resolver": "^5.0.0",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.13",
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "babel-plugin-module-resolver": "^5.0.2",
     "babel-plugin-named-exports-order": "^0.0.2",
     "customize-cra": "^1.0.0",
-    "eslint-plugin-storybook": "^0.6.15",
+    "eslint-plugin-storybook": "^0.8.0",
     "prop-types": "^15.8.1",
-    "react-app-rewired": "^2.2.1",
     "react-error-overlay": "6.0.11",
     "react-scripts": "^5.0.1",
-    "storybook": "^7.4.6",
     "tslint": "^6.1.3",
-    "typescript": "^4.3.2",
-    "webpack": "^5.88.2"
+    "typescript": "^4.9.5",
+    "webpack": "^5.94.0"
   }
 }


### PR DESCRIPTION
- Upgraded to latest set of packages that work together
- Resolved all vulnerabilities for production
- Made audit only run on production as part of npm install to prevent noise of dev dependencies from hiding potential production vulernabilities