### PR TITLE
Issues under Requests tab can now show issues from multiple projects

### DIFF
--- a/src/components/graphql/UserIssues.tsx
+++ b/src/components/graphql/UserIssues.tsx
@@ -77,7 +77,6 @@ const UserIssues: React.FC<UserIssuesProps> = (props: UserIssuesProps) => {
   
   // Figure out our variables for the query
   const variables = () => {
-    const fullPath = `${organization}/${props.project}`;
     if ( props.username === 'none' ) {
 
       // If there is no user, we need to use team labels to filter down the unassigned issues
@@ -85,14 +84,14 @@ const UserIssues: React.FC<UserIssuesProps> = (props: UserIssuesProps) => {
         username: 'none', 
         milestones: [props.milestone.title],  
         labels: props.labels,
-        fullPath,
+        fullPath: organization, // for Requests tab return all issues in the organization
       };
     }
     else if ( props.username === 'fixes' ) {
       return { 
         milestones: [props.milestone.title], 
         labels: [...props.labels || [], '🐞 Bug'],
-        fullPath,
+        fullPath: organization, // for Fixes tab return all issues in the organization
       };
     }
     else {
@@ -143,6 +142,10 @@ const UserIssues: React.FC<UserIssuesProps> = (props: UserIssuesProps) => {
 
   // Extract our issues from the data returned
   const issueNodes = issuesQuery.data?.group?.issues?.nodes || issuesQuery.data?.project?.issues?.nodes || [];
+
+  // Get the IDs of all of our projects
+  const projectIds: number[] =  Object.values(projects)
+  const projectIssueNodes = issueNodes.filter(node => projectIds.includes((node as any).projectId))
 
   // Get any epics associated with these issues
   // ...
@@ -275,7 +278,7 @@ const UserIssues: React.FC<UserIssuesProps> = (props: UserIssuesProps) => {
   }
 
   // Determine if we've set orderings before... only happens once data gets loaded the first time
-  const { sortedItems, orderingSnapshot } = durableOrder(issueNodes, orderingForIssue, orderingsRef.current);
+  const { sortedItems, orderingSnapshot } = durableOrder(projectIssueNodes, orderingForIssue, orderingsRef.current);
   orderingsRef.current = orderingSnapshot;
   
   const issuesToShow = () => sortedItems.map((issue: any) => 

--- a/src/data/customize.ts
+++ b/src/data/customize.ts
@@ -1,4 +1,4 @@
-import { TeamLink, Team, User } from './types'
+import { TeamLink, Team, User, Project } from './types'
 
 export const organization = 'companyname'
 
@@ -9,6 +9,11 @@ const sharedLinks: TeamLink[] = [
 export const teams: Team[] = [
   { name: 'Team 1', project: 'project1', projectId: 1, labels: [], links: sharedLinks },
   { name: 'Team 2', project: 'project2', projectId: 2, labels: [], links: sharedLinks },
+]
+
+export const projects: Project[] = [
+  { name: 'Project 1', project: 'project1', projectId: 1, labels: [] },
+  { name: 'Project 2', project: 'project2', projectId: 2, labels: [] },
 ]
 
 export const users: User[] = [

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,11 +1,11 @@
 import { ProjectMap } from './types';
-import { teams as teamsList } from './customize';
+import { teams as teamsList, projects as projectsList } from './customize';
 
 // Convert list of teams into projectName and productId name value pairs
-export const projects: ProjectMap = teamsList.reduce((projects: ProjectMap, team: any) => {
-  const project = team.project;
+export const projects: ProjectMap = projectsList.reduce((projects: ProjectMap, item: any) => {
+  const project = item.project;
   if (project) {
-    projects[project] = team.projectId;
+    projects[project] = item.projectId;
   }
   return projects;
 }, {})

--- a/src/data/queries/gitlab/graphql.ts
+++ b/src/data/queries/gitlab/graphql.ts
@@ -234,7 +234,7 @@ export const OPEN_ISSUES_NO_MILESTONE = gql`
 
 export const ALL_BUG_ISSUES = gql`
   query GetAllBugs($milestones: [String], $labels: [String], $fullPath: ID!) {
-    project(fullPath: $fullPath) {
+    group(fullPath: $fullPath) {
       id,
       name,
       issues (milestoneTitle: $milestones,
@@ -251,7 +251,7 @@ export const ALL_BUG_ISSUES = gql`
 
 export const ALL_FIXED_BUG_ISSUES = gql`
   query GetAllFixedBugs($milestones: [String], $labels: [String], $fullPath: ID!) {
-    project(fullPath: $fullPath) {
+    group(fullPath: $fullPath) {
       id,
       name,
       issues (milestoneTitle: $milestones,
@@ -269,7 +269,7 @@ export const ALL_FIXED_BUG_ISSUES = gql`
 
 export const ALL_OPEN_BUG_ISSUES = gql`
   query GetAllOpenBugs($milestones: [String], $labels: [String], $fullPath: ID!) {
-    project(fullPath: $fullPath) {
+    group(fullPath: $fullPath) {
       id,
       name,
       issues (milestoneTitle: $milestones,
@@ -326,7 +326,7 @@ export const CLOSED_ISSUES = gql`
 
 export const OPEN_UNASSIGNED_ISSUES = gql`
   query GetOpenUserIssues($milestones: [String], $labels: [String], $fullPath: ID!) {
-    project(fullPath: $fullPath) {
+    group(fullPath: $fullPath) {
       id,
       name,
       issues (assigneeId: "None", 
@@ -345,7 +345,7 @@ export const OPEN_UNASSIGNED_ISSUES = gql`
 
 export const OPEN_UNASSIGNED_ISSUES_NO_MILESTONE = gql`
   query GetOpenUserIssuesNoMilestone($labels: [String], $fullPath: ID!) {
-    project(fullPath: $fullPath) {
+    group(fullPath: $fullPath) {
       id,
       name,
       issues (assigneeId: "None", 

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -38,6 +38,13 @@ export interface Team {
   links?: TeamLink[];
 }
 
+export interface Project {
+  name: string;
+  labels: string[];
+  project: string;
+  projectId?: number;
+}
+
 export interface User {
   name: string;
   username: string;


### PR DESCRIPTION
When we have users working on different project repo's in a single team, it's helpful to be able to see open requests across all projects.

Now, any GitLab project can be added to customize.ts and issues from it will show up under the Requests tab.